### PR TITLE
Patch: fix loader and maximum request attempts

### DIFF
--- a/ui/src/actions/metadataActions.js
+++ b/ui/src/actions/metadataActions.js
@@ -3,8 +3,12 @@ import asyncActionCreator from 'actions/asyncActionCreator';
 
 export const fetchMetadata = asyncActionCreator(
   () => async () => {
-    const response = await endpoint.get('metadata');
-    return { metadata: response.data };
+    try {
+      const response = await endpoint.get('metadata');
+      return { metadata: response.data };
+    } catch (e) {
+      throw e;
+    }
   },
   { name: 'FETCH_METADATA' }
 );

--- a/ui/src/app/Router.jsx
+++ b/ui/src/app/Router.jsx
@@ -106,12 +106,6 @@ class Router extends Component {
     const delay = this.state.metadataRequestAttempts * DELAY_METADATA_REQUEST;
 
     const functionRef = () => {
-      // eslint-disable-next-line
-      console.log(
-        'metadataRequestAttempts',
-        this.state.metadataRequestAttempts
-      );
-
       this.props.fetchMetadata();
     };
 


### PR DESCRIPTION
The patch uses two different protection techniques. 

`#1` 
`state. metadataRequestAttempts` tracks how many attempts are requested to axios REST API layer. The current restrictions to `const MAX_METADATA_REQUEST_ATTEMPTS = 5;`

`#2` 
`executeRetryPattern` uses `setTimeout`. `setTimeout` is going to be increased each time if the request has any error.

#### Accomplishments

`#1` 
The previous version executed many request without any delay between requests. 
<img width="779" alt="Screenshot 2024-07-16 at 10 07 03 AM" src="https://github.com/user-attachments/assets/b6c53412-37e7-4cb9-89e5-ad0245d66a1b">

`#2` 
The gap between UI pop dialog is increased from a few ms to 2000+ ms. 

<img width="484" alt="Screenshot 2024-07-16 at 10 11 57 AM" src="https://github.com/user-attachments/assets/2bc1cd15-2347-44a4-b9af-5578b9422319">
